### PR TITLE
Add theme system and Tailwind config

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -22,3 +22,7 @@ AUTH_DISCORD_SECRET=""
 # Prisma
 # https://www.prisma.io/docs/reference/database-reference/connection-urls#env
 DATABASE_URL="postgresql://postgres:password@localhost:5432/fahndung-a"
+
+# Supabase
+NEXT_PUBLIC_SUPABASE_URL="http://localhost:54321"
+NEXT_PUBLIC_SUPABASE_ANON_KEY=""

--- a/docs/README.md
+++ b/docs/README.md
@@ -60,4 +60,11 @@ pnpm start
 ### Sicherheit
 - Row Level Security (RLS) aktiviert
 - Environment Variables über Vercel verwaltet
-- Auth-Guards für geschützte Routen 
+- Auth-Guards für geschützte Routen
+
+## 🎨 Theme und Farbpalette
+
+Die Anwendung nutzt eine moderne Tailwind-Konfiguration mit HSL-basierten CSS Variablen.
+Der `ThemeProvider` erkennt das System-Theme und erlaubt einen manuellen Wechsel
+zwischen Hell- und Dunkelmodus. Die Farbwerte sind in `globals.css` definiert und
+werden in `tailwind.config.js` eingebunden.

--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
     "@types/node": "^20.14.10",
     "@types/react": "^19.1.8",
     "@types/react-dom": "^19.1.6",
+    "autoprefixer": "^10.4.21",
     "eslint": "^9.23.0",
     "eslint-config-next": "^15.2.3",
     "postcss": "^8.5.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -84,6 +84,9 @@ importers:
       '@types/react-dom':
         specifier: ^19.1.6
         version: 19.1.6(@types/react@19.1.8)
+      autoprefixer:
+        specifier: ^10.4.21
+        version: 10.4.21(postcss@8.5.6)
       eslint:
         specifier: ^9.23.0
         version: 9.31.0(jiti@2.4.2)
@@ -895,6 +898,13 @@ packages:
     resolution: {integrity: sha512-hsU18Ae8CDTR6Kgu9DYf0EbCr/a5iGL0rytQDobUcdpYOKokk8LEjVphnXkDkgpi0wYVsqrXuP0bZxJaTqdgoA==}
     engines: {node: '>= 0.4'}
 
+  autoprefixer@10.4.21:
+    resolution: {integrity: sha512-O+A6LWV5LDHSJD3LjHYoNi4VLsj/Whi7k6zG12xTYaU4cQ8oxQGckXNX8cRHK5yOZ/ppVHe0ZBXGzSV9jXdVbQ==}
+    engines: {node: ^10 || ^12 || >=14}
+    hasBin: true
+    peerDependencies:
+      postcss: ^8.1.0
+
   available-typed-arrays@1.0.7:
     resolution: {integrity: sha512-wvUjBtSGN7+7SjNpq/9M2Tg350UZD3q62IFZLbRAR1bSMlCo1ZaeW+BJ+D090e4hIIZLBcTDWe4Mh4jvUDajzQ==}
     engines: {node: '>= 0.4'}
@@ -919,6 +929,11 @@ packages:
   braces@3.0.3:
     resolution: {integrity: sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==}
     engines: {node: '>=8'}
+
+  browserslist@4.25.1:
+    resolution: {integrity: sha512-KGj0KoOMXLpSNkkEI6Z6mShmQy0bc1I+T7K9N81k4WWMrfz+6fQ6es80B/YLAeRoKvjYE1YSHHOW1qe9xIVzHw==}
+    engines: {node: ^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7}
+    hasBin: true
 
   call-bind-apply-helpers@1.0.2:
     resolution: {integrity: sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==}
@@ -1044,6 +1059,9 @@ packages:
     resolution: {integrity: sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==}
     engines: {node: '>= 0.4'}
 
+  electron-to-chromium@1.5.187:
+    resolution: {integrity: sha512-cl5Jc9I0KGUoOoSbxvTywTa40uspGJt/BDBoDLoxJRSBpWh4FFXBsjNRHfQrONsV/OoEjDfHUmZQa2d6Ze4YgA==}
+
   emoji-regex@9.2.2:
     resolution: {integrity: sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==}
 
@@ -1082,6 +1100,10 @@ packages:
   es-to-primitive@1.3.0:
     resolution: {integrity: sha512-w+5mJ3GuFL+NjVtJlvydShqE1eN3h3PbI7/5LAsYJP/2qtuMXjfL2LpHSRqo4b4eSF5K/DH1JXKUAHSB2UW50g==}
     engines: {node: '>= 0.4'}
+
+  escalade@3.2.0:
+    resolution: {integrity: sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==}
+    engines: {node: '>=6'}
 
   escape-string-regexp@4.0.0:
     resolution: {integrity: sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==}
@@ -1253,6 +1275,9 @@ packages:
   for-each@0.3.5:
     resolution: {integrity: sha512-dKx12eRCVIzqCxFGplyFKJMPvLEWgmNtUrpTiJIR5u97zEhRG8ySrtboPHZXx7daLxQVrl643cTzbab2tkQjxg==}
     engines: {node: '>= 0.4'}
+
+  fraction.js@4.3.7:
+    resolution: {integrity: sha512-ZsDfxO51wGAXREY55a7la9LScWpwv9RxIrYABrlvOFBlH/ShPnrtsXeuUIfXKKOVicNxQ+o8JTbJvjS4M89yew==}
 
   function-bind@1.1.2:
     resolution: {integrity: sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==}
@@ -1674,6 +1699,13 @@ packages:
       sass:
         optional: true
 
+  node-releases@2.0.19:
+    resolution: {integrity: sha512-xxOWJsBKtzAq7DY0J+DTzuz58K8e7sJbdgwkbMWQe8UYB6ekmsQ45q0M/tJDsGaZmbC+l7n57UV8Hl5tHxO9uw==}
+
+  normalize-range@0.1.2:
+    resolution: {integrity: sha512-bdok/XvKII3nUpklnV6P2hxtMNrCboOjAcyBuQnWEhO665FwrSNRxU+AqpsyvO6LgGYPspN+lu5CLtw4jPRKNA==}
+    engines: {node: '>=0.10.0'}
+
   object-assign@4.1.1:
     resolution: {integrity: sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==}
     engines: {node: '>=0.10.0'}
@@ -1751,6 +1783,9 @@ packages:
   possible-typed-array-names@1.1.0:
     resolution: {integrity: sha512-/+5VFTchJDoVj3bhoqi6UeymcD00DAwb1nJwamzPvHEszJ4FpF6SNNbUbOS8yI56qHzdV8eK0qEfOSiodkTdxg==}
     engines: {node: '>= 0.4'}
+
+  postcss-value-parser@4.2.0:
+    resolution: {integrity: sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==}
 
   postcss@8.4.31:
     resolution: {integrity: sha512-PS08Iboia9mts/2ygV3eLpY5ghnUcfLV/EXTOW1E2qYxJKGGBUtNjN76FYHnMs36RmARn41bC0AZmn+rR0OVpQ==}
@@ -2098,6 +2133,12 @@ packages:
 
   unrs-resolver@1.11.1:
     resolution: {integrity: sha512-bSjt9pjaEBnNiGgc9rUiHGKv5l4/TGzDmYw3RhnkJGtLhbnnA/5qJj7x3dNDCRx/PJxu774LlH8lCOlB4hEfKg==}
+
+  update-browserslist-db@1.1.3:
+    resolution: {integrity: sha512-UxhIZQ+QInVdunkDAaiazvvT/+fXL5Osr0JZlJulepYu6Jd7qJtDZjlur0emRlT71EN3ScPoE7gvsuIKKNavKw==}
+    hasBin: true
+    peerDependencies:
+      browserslist: '>= 4.21.0'
 
   uri-js@4.4.1:
     resolution: {integrity: sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==}
@@ -2859,6 +2900,16 @@ snapshots:
 
   async-function@1.0.0: {}
 
+  autoprefixer@10.4.21(postcss@8.5.6):
+    dependencies:
+      browserslist: 4.25.1
+      caniuse-lite: 1.0.30001727
+      fraction.js: 4.3.7
+      normalize-range: 0.1.2
+      picocolors: 1.1.1
+      postcss: 8.5.6
+      postcss-value-parser: 4.2.0
+
   available-typed-arrays@1.0.7:
     dependencies:
       possible-typed-array-names: 1.1.0
@@ -2881,6 +2932,13 @@ snapshots:
   braces@3.0.3:
     dependencies:
       fill-range: 7.1.1
+
+  browserslist@4.25.1:
+    dependencies:
+      caniuse-lite: 1.0.30001727
+      electron-to-chromium: 1.5.187
+      node-releases: 2.0.19
+      update-browserslist-db: 1.1.3(browserslist@4.25.1)
 
   call-bind-apply-helpers@1.0.2:
     dependencies:
@@ -3006,6 +3064,8 @@ snapshots:
       es-errors: 1.3.0
       gopd: 1.2.0
 
+  electron-to-chromium@1.5.187: {}
+
   emoji-regex@9.2.2: {}
 
   enhanced-resolve@5.18.2:
@@ -3113,6 +3173,8 @@ snapshots:
       is-callable: 1.2.7
       is-date-object: 1.1.0
       is-symbol: 1.1.1
+
+  escalade@3.2.0: {}
 
   escape-string-regexp@4.0.0: {}
 
@@ -3366,6 +3428,8 @@ snapshots:
   for-each@0.3.5:
     dependencies:
       is-callable: 1.2.7
+
+  fraction.js@4.3.7: {}
 
   function-bind@1.1.2: {}
 
@@ -3762,6 +3826,10 @@ snapshots:
       - '@babel/core'
       - babel-plugin-macros
 
+  node-releases@2.0.19: {}
+
+  normalize-range@0.1.2: {}
+
   object-assign@4.1.1: {}
 
   object-inspect@1.13.4: {}
@@ -3844,6 +3912,8 @@ snapshots:
   picomatch@4.0.3: {}
 
   possible-typed-array-names@1.1.0: {}
+
+  postcss-value-parser@4.2.0: {}
 
   postcss@8.4.31:
     dependencies:
@@ -4243,6 +4313,12 @@ snapshots:
       '@unrs/resolver-binding-win32-arm64-msvc': 1.11.1
       '@unrs/resolver-binding-win32-ia32-msvc': 1.11.1
       '@unrs/resolver-binding-win32-x64-msvc': 1.11.1
+
+  update-browserslist-db@1.1.3(browserslist@4.25.1):
+    dependencies:
+      browserslist: 4.25.1
+      escalade: 3.2.0
+      picocolors: 1.1.1
 
   uri-js@4.4.1:
     dependencies:

--- a/postcss.config.js
+++ b/postcss.config.js
@@ -1,5 +1,6 @@
 export default {
   plugins: {
-    "@tailwindcss/postcss": {},
+    '@tailwindcss/postcss': {},
+    autoprefixer: {},
   },
 };

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -3,48 +3,71 @@
 
 /* ===== GLOBALE VARIABLEN ===== */
 :root {
-  /* Hauptfarben */
-  --primary-blue: #3b82f6;
-  --primary-blue-hover: #2563eb;
-  --primary-green: #10b981;
-  --primary-green-hover: #059669;
-  --primary-red: #ef4444;
-  --primary-red-hover: #dc2626;
-  --primary-yellow: #f59e0b;
-  --primary-yellow-hover: #d97706;
-  --primary-purple: #8b5cf6;
-  --primary-purple-hover: #7c3aed;
+  /* Theme Farben (Light Mode) */
+  --background: 0 0% 100%;
+  --foreground: 240 10% 10%;
 
-  /* Grau-Skala */
-  --gray-50: #f9fafb;
-  --gray-100: #f3f4f6;
-  --gray-200: #e5e7eb;
-  --gray-300: #d1d5db;
-  --gray-400: #9ca3af;
-  --gray-500: #6b7280;
-  --gray-600: #4b5563;
-  --gray-700: #374151;
-  --gray-800: #1f2937;
-  --gray-900: #111827;
+  --card: 0 0% 100%;
+  --card-foreground: 240 10% 10%;
 
-  /* Transparenz */
-  --white-5: rgba(255, 255, 255, 0.05);
-  --white-10: rgba(255, 255, 255, 0.1);
-  --white-20: rgba(255, 255, 255, 0.2);
-  --white-40: rgba(255, 255, 255, 0.4);
-  --white-50: rgba(255, 255, 255, 0.5);
-  --white-80: rgba(255, 255, 255, 0.8);
+  --popover: 0 0% 100%;
+  --popover-foreground: 240 10% 10%;
 
-  /* Schatten */
-  --shadow-sm: 0 1px 2px 0 rgba(0, 0, 0, 0.05);
-  --shadow-md: 0 4px 6px -1px rgba(0, 0, 0, 0.1);
-  --shadow-lg: 0 10px 15px -3px rgba(0, 0, 0, 0.1);
-  --shadow-xl: 0 20px 25px -5px rgba(0, 0, 0, 0.1);
+  --primary: 242 80% 60%;
+  --primary-foreground: 0 0% 100%;
+
+  --secondary: 210 40% 96%;
+  --secondary-foreground: 240 10% 20%;
+
+  --muted: 240 4% 95%;
+  --muted-foreground: 240 5% 40%;
+
+  --accent: 242 80% 95%;
+  --accent-foreground: 242 80% 30%;
+
+  --destructive: 0 85% 60%;
+  --destructive-foreground: 0 0% 100%;
+
+  --border: 240 6% 90%;
+  --input: 240 6% 90%;
+  --ring: 242 80% 60%;
+
+  --radius: 0.5rem;
 
   /* Animationen */
   --transition-fast: 150ms ease-in-out;
   --transition-normal: 300ms ease-in-out;
   --transition-slow: 500ms ease-in-out;
+}
+
+.dark {
+  --background: 240 10% 10%;
+  --foreground: 0 0% 100%;
+
+  --card: 240 10% 20%;
+  --card-foreground: 0 0% 100%;
+
+  --popover: 240 10% 20%;
+  --popover-foreground: 0 0% 100%;
+
+  --primary: 242 80% 60%;
+  --primary-foreground: 0 0% 100%;
+
+  --secondary: 240 5% 30%;
+  --secondary-foreground: 0 0% 100%;
+
+  --muted: 240 5% 40%;
+  --muted-foreground: 0 0% 100%;
+
+  --accent: 242 80% 30%;
+  --accent-foreground: 0 0% 100%;
+
+  --destructive: 0 63% 50%;
+  --destructive-foreground: 0 0% 100%;
+
+  --border: 240 5% 50%;
+  --input: 240 5% 50%;
+  --ring: 242 80% 60%;
 }
 
 /* ===== BASIS-STILE ===== */
@@ -55,9 +78,13 @@
 body {
   font-family: var(--font-geist-sans), -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
   line-height: 1.6;
-  color: white;
-  background: linear-gradient(135deg, #1e293b 0%, #7c3aed 50%, #1e293b 100%);
-  min-height: 100vh;
+  @apply bg-background text-foreground min-h-screen;
+  background-image: linear-gradient(
+    135deg,
+    hsl(var(--background)) 0%,
+    hsl(var(--primary)) 50%,
+    hsl(var(--background)) 100%
+  );
 }
 
 /* ===== EINHEITLICHE KOMPONENTEN ===== */
@@ -69,28 +96,28 @@ body {
 }
 
 .btn-primary {
-  @apply bg-blue-600 text-white hover:bg-blue-700;
-  @apply focus:ring-blue-500;
+  @apply bg-primary text-primary-foreground hover:bg-primary/90;
+  @apply focus:ring-ring;
 }
 
 .btn-secondary {
-  @apply bg-gray-600 text-white hover:bg-gray-700;
-  @apply focus:ring-gray-500;
+  @apply bg-secondary text-secondary-foreground hover:bg-secondary/80;
+  @apply focus:ring-ring;
 }
 
 .btn-success {
   @apply bg-green-600 text-white hover:bg-green-700;
-  @apply focus:ring-green-500;
+  @apply focus:ring-ring;
 }
 
 .btn-danger {
-  @apply bg-red-600 text-white hover:bg-red-700;
-  @apply focus:ring-red-500;
+  @apply bg-destructive text-destructive-foreground hover:bg-destructive/90;
+  @apply focus:ring-ring;
 }
 
 .btn-warning {
   @apply bg-yellow-600 text-white hover:bg-yellow-700;
-  @apply focus:ring-yellow-500;
+  @apply focus:ring-ring;
 }
 
 .btn-outline {
@@ -117,17 +144,17 @@ body {
 
 /* Card-Stile */
 .card {
-  @apply bg-white/5 backdrop-blur-sm rounded-lg border border-white/10;
+  @apply bg-card text-card-foreground backdrop-blur-sm rounded-lg border border-border;
   @apply transition-all duration-300;
 }
 
 .card-hover {
-  @apply hover:bg-white/10 hover:border-white/20;
+  @apply hover:bg-accent/20 hover:border-accent;
 }
 
 .card-interactive {
-  @apply cursor-pointer hover:bg-white/10 hover:border-white/20;
-  @apply active:bg-white/15 active:scale-95;
+  @apply cursor-pointer hover:bg-accent/20 hover:border-accent;
+  @apply active:bg-accent/30 active:scale-95;
 }
 
 /* Badge-Stile */

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -5,6 +5,7 @@ import { Geist } from "next/font/google";
 
 import { TRPCReactProvider } from "~/trpc/react";
 import { SessionInitializer } from "~/components/SessionInitializer";
+import { ThemeProvider } from "~/components/ThemeProvider";
 
 export const metadata: Metadata = {
   title: "Create T3 App",
@@ -23,10 +24,12 @@ export default function RootLayout({
   return (
     <html lang="en" className={`${geist.variable}`}>
       <body suppressHydrationWarning={true}>
-        <TRPCReactProvider>
-          <SessionInitializer />
-          {children}
-        </TRPCReactProvider>
+        <ThemeProvider>
+          <TRPCReactProvider>
+            <SessionInitializer />
+            {children}
+          </TRPCReactProvider>
+        </ThemeProvider>
       </body>
     </html>
   );

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -4,6 +4,7 @@
 import { useRouter } from 'next/navigation'
 import Link from 'next/link'
 import { AlertTriangle, User, LogIn, Plus } from 'lucide-react'
+import { ThemeToggle } from '@/components/ui/theme-toggle'
 
 export default function Home() {
   const router = useRouter();
@@ -21,9 +22,9 @@ export default function Home() {
   };
 
   return (
-    <main className="min-h-screen bg-gradient-to-br from-slate-900 via-purple-900 to-slate-900">
+    <main className="min-h-screen bg-gradient-to-br from-background via-primary to-background">
       {/* Header */}
-      <header className="border-b border-white/10 bg-white/5 backdrop-blur-sm">
+      <header className="border-b border-border bg-card/50 backdrop-blur-sm">
         <div className="container mx-auto px-4 py-4">
           <div className="flex items-center justify-between">
             <Link href="/" className="flex items-center space-x-3 cursor-pointer hover:opacity-80 transition-opacity">
@@ -31,20 +32,21 @@ export default function Home() {
               <h1 className="text-2xl font-bold text-white">Fahndung</h1>
             </Link>
             <div className="flex items-center space-x-4">
-              <button 
+              <button
                 onClick={handleDashboard}
-                className="flex items-center space-x-2 rounded-lg bg-blue-600 px-4 py-2 text-white hover:bg-blue-700 transition-colors"
+                className="flex items-center space-x-2 rounded-lg bg-primary px-4 py-2 text-primary-foreground hover:bg-primary/90 transition-colors"
               >
                 <User className="h-4 w-4" />
                 <span>Dashboard</span>
               </button>
-              <button 
+              <button
                 onClick={handleLogin}
-                className="flex items-center space-x-2 rounded-lg bg-green-600 px-4 py-2 text-white hover:bg-green-700 transition-colors"
+                className="flex items-center space-x-2 rounded-lg bg-secondary px-4 py-2 text-secondary-foreground hover:bg-secondary/80 transition-colors"
               >
                 <LogIn className="h-4 w-4" />
                 <span>Anmelden</span>
               </button>
+              <ThemeToggle />
             </div>
           </div>
         </div>
@@ -60,13 +62,13 @@ export default function Home() {
             <h1 className="text-4xl font-bold text-white mb-4">
               Willkommen beim Fahndungssystem
             </h1>
-            <p className="text-xl text-gray-300 mb-8">
+            <p className="text-xl text-muted-foreground mb-8">
               Professionelle Fahndungserstellung mit Supabase-Integration
             </p>
             <div className="flex items-center justify-center space-x-4">
-              <button 
+              <button
                 onClick={handleWizard}
-                className="flex items-center space-x-2 rounded-lg bg-blue-600 px-6 py-3 text-white font-medium hover:bg-blue-700 transition-colors"
+                className="flex items-center space-x-2 rounded-lg bg-primary px-6 py-3 text-primary-foreground font-medium hover:bg-primary/90 transition-colors"
               >
                 <Plus className="h-5 w-5" />
                 <span>Neue Fahndung erstellen</span>
@@ -77,21 +79,21 @@ export default function Home() {
 
           {/* Features */}
           <div className="grid grid-cols-1 md:grid-cols-3 gap-6">
-            <div className="bg-white/5 backdrop-blur-sm rounded-lg border border-white/10 p-6">
+            <div className="bg-card/50 backdrop-blur-sm rounded-lg border border-border p-6">
               <div className="text-center">
                 <AlertTriangle className="h-12 w-12 mx-auto text-red-400 mb-4" />
                 <h3 className="text-lg font-semibold text-white mb-2">Fahndungserstellung</h3>
-                <p className="text-gray-400 text-sm">
+                <p className="text-muted-foreground text-sm">
                   Erstellen Sie professionelle Fahndungen mit unserem intuitiven Wizard-System
                 </p>
               </div>
             </div>
             
-            <div className="bg-white/5 backdrop-blur-sm rounded-lg border border-white/10 p-6">
+            <div className="bg-card/50 backdrop-blur-sm rounded-lg border border-border p-6">
               <div className="text-center">
                 <User className="h-12 w-12 mx-auto text-blue-400 mb-4" />
                 <h3 className="text-lg font-semibold text-white mb-2">Benutzer-Management</h3>
-                <p className="text-gray-400 text-sm">
+                <p className="text-muted-foreground text-sm">
                   Verwalten Sie Benutzer und Berechtigungen mit Admin-Tools
                 </p>
               </div>
@@ -101,24 +103,24 @@ export default function Home() {
           </div>
 
           {/* System-Status */}
-          <div className="bg-white/5 backdrop-blur-sm rounded-lg border border-white/10 p-6">
+          <div className="bg-card/50 backdrop-blur-sm rounded-lg border border-border p-6">
             <h2 className="text-xl font-semibold text-white mb-4">System-Status</h2>
             <div className="grid grid-cols-2 md:grid-cols-4 gap-4 text-sm">
               <div className="flex items-center space-x-2">
                 <div className="w-3 h-3 bg-green-500 rounded-full"></div>
-                <span className="text-gray-300">Wizard: Aktiv</span>
+                <span className="text-muted-foreground">Wizard: Aktiv</span>
               </div>
               <div className="flex items-center space-x-2">
                 <div className="w-3 h-3 bg-green-500 rounded-full"></div>
-                <span className="text-gray-300">Supabase: Verbunden</span>
+                <span className="text-muted-foreground">Supabase: Verbunden</span>
               </div>
               <div className="flex items-center space-x-2">
                 <div className="w-3 h-3 bg-green-500 rounded-full"></div>
-                <span className="text-gray-300">Datenbank: Online</span>
+                <span className="text-muted-foreground">Datenbank: Online</span>
               </div>
               <div className="flex items-center space-x-2">
                 <div className="w-3 h-3 bg-green-500 rounded-full"></div>
-                <span className="text-gray-300">Admin: Verfügbar</span>
+                <span className="text-muted-foreground">Admin: Verfügbar</span>
               </div>
             </div>
           </div>

--- a/src/components/ThemeProvider.tsx
+++ b/src/components/ThemeProvider.tsx
@@ -1,0 +1,44 @@
+'use client'
+import { createContext, useContext, useEffect, useState } from 'react'
+
+type Theme = 'light' | 'dark'
+
+interface ThemeContextValue {
+  theme: Theme
+  toggleTheme: () => void
+}
+
+const ThemeContext = createContext<ThemeContextValue>({
+  theme: 'light',
+  // eslint-disable-next-line @typescript-eslint/no-empty-function
+  toggleTheme: () => {},
+})
+
+export function ThemeProvider({ children }: { children: React.ReactNode }) {
+  const [theme, setTheme] = useState<Theme>('light')
+
+  useEffect(() => {
+    const saved = localStorage.getItem('theme') as Theme | null
+    const systemPrefersDark = window.matchMedia('(prefers-color-scheme: dark)').matches
+    const initial = saved ?? (systemPrefersDark ? 'dark' : 'light')
+    setTheme(initial)
+    document.documentElement.classList.toggle('dark', initial === 'dark')
+  }, [])
+
+  const toggleTheme = () => {
+    const next = theme === 'dark' ? 'light' : 'dark'
+    setTheme(next)
+    document.documentElement.classList.toggle('dark', next === 'dark')
+    localStorage.setItem('theme', next)
+  }
+
+  return (
+    <ThemeContext.Provider value={{ theme, toggleTheme }}>
+      {children}
+    </ThemeContext.Provider>
+  )
+}
+
+export function useTheme() {
+  return useContext(ThemeContext)
+}

--- a/src/components/ui/theme-toggle.tsx
+++ b/src/components/ui/theme-toggle.tsx
@@ -1,0 +1,14 @@
+'use client'
+import { Moon, Sun } from 'lucide-react'
+import { Button } from './button'
+import { useTheme } from '../ThemeProvider'
+
+export function ThemeToggle() {
+  const { theme, toggleTheme } = useTheme()
+  return (
+    <Button variant="ghost" size="icon" onClick={toggleTheme}>
+      {theme === 'dark' ? <Sun className="h-4 w-4" /> : <Moon className="h-4 w-4" />}
+      <span className="sr-only">Toggle theme</span>
+    </Button>
+  )
+}

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,0 +1,59 @@
+/** @type {import('tailwindcss').Config} */
+module.exports = {
+  content: [
+    './src/**/*.{ts,tsx}',
+    './src/app/**/*.{ts,tsx}',
+    './src/components/**/*.{ts,tsx}',
+  ],
+  darkMode: 'class',
+  theme: {
+    container: {
+      center: true,
+    },
+    extend: {
+      colors: {
+        border: 'hsl(var(--border))',
+        input: 'hsl(var(--input))',
+        ring: 'hsl(var(--ring))',
+        background: 'hsl(var(--background))',
+        foreground: 'hsl(var(--foreground))',
+        primary: {
+          DEFAULT: 'hsl(var(--primary))',
+          foreground: 'hsl(var(--primary-foreground))',
+        },
+        secondary: {
+          DEFAULT: 'hsl(var(--secondary))',
+          foreground: 'hsl(var(--secondary-foreground))',
+        },
+        destructive: {
+          DEFAULT: 'hsl(var(--destructive))',
+          foreground: 'hsl(var(--destructive-foreground))',
+        },
+        muted: {
+          DEFAULT: 'hsl(var(--muted))',
+          foreground: 'hsl(var(--muted-foreground))',
+        },
+        accent: {
+          DEFAULT: 'hsl(var(--accent))',
+          foreground: 'hsl(var(--accent-foreground))',
+        },
+        popover: {
+          DEFAULT: 'hsl(var(--popover))',
+          foreground: 'hsl(var(--popover-foreground))',
+        },
+        card: {
+          DEFAULT: 'hsl(var(--card))',
+          foreground: 'hsl(var(--card-foreground))',
+        },
+      },
+      borderRadius: {
+        lg: 'var(--radius)',
+      },
+    },
+  },
+  plugins: [
+    require('@tailwindcss/forms'),
+    require('@tailwindcss/typography'),
+    require('@tailwindcss/aspect-ratio'),
+  ],
+};


### PR DESCRIPTION
## Summary
- add Tailwind configuration with extended colors
- introduce ThemeProvider and theme toggle
- convert global styles to CSS variables and dark mode
- use palette utilities on home page
- document the new theme setup

## Testing
- `pnpm lint`
- `pnpm build`

------
https://chatgpt.com/codex/tasks/task_e_687cc7e376108328b7363e4c6dd300e6